### PR TITLE
Add host MANET setup and discovery utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ Instructions to compile, install, and run bladeRF-wiphy and tools https://www.nu
 
 Instructions to simulate bladeRF-wiphy: https://www.nuand.com/bladeRF-wiphy-simulation/
 
+### MANET bring-up helpers
+
+This repository now includes host-side tooling that follows the roadmap
+described in [`docs/manet_plan.md`](docs/manet_plan.md) to establish an ad-hoc
+link between two bladeRF-wiphy nodes.  The utilities live under
+[`host/manet`](host/manet) and provide:
+
+- `setup_ibss.py`: Automates joining an IEEE 802.11 IBSS cell, assigns IP
+  addressing, and can optionally launch an OLSR/OLSRv2 routing daemon to begin
+  exchanging MANET control traffic.
+- `hello_daemon.py`: A lightweight UDP neighbor discovery loop that mirrors the
+  NHDP step of the MANET plan, allowing quick validation that both radios see
+  each other once the IBSS link is established.
+
+See [`host/manet/README.md`](host/manet/README.md) for detailed usage examples.
+
 <p align="center">
 <img width="50%" height="50%" src="https://www.nuand.com/wp-content/uploads/2021/01/bw-block-diagram.png">
 </p>

--- a/docs/external_sources.md
+++ b/docs/external_sources.md
@@ -1,0 +1,25 @@
+# External MANET References
+
+## Wireless ad hoc network (Wikipedia)
+- Excerpt: "A wireless ad hoc network (WANET) or mobile ad hoc network (MANET) is a decentralized type of wireless network... Each node participates in routing by forwarding data for other nodes." (Accessed via https://en.wikipedia.org/api/rest_v1/page/summary/Wireless_ad_hoc_network)
+- License: CC BY-SA 4.0
+
+## IEEE 802.11s (Wikipedia)
+- Excerpt: "IEEE 802.11s is a wireless local area network (WLAN) standard and an IEEE 802.11 amendment for mesh networking, defining how wireless devices can interconnect to create a wireless LAN mesh network..." (Accessed via https://en.wikipedia.org/api/rest_v1/page/summary/IEEE_802.11s)
+- License: CC BY-SA 4.0
+
+## Optimized Link State Routing Protocol (OLSR) (Wikipedia)
+- Excerpt: "The Optimized Link State Routing Protocol (OLSR) is an IP routing protocol optimized for mobile ad hoc networks... OLSR is a proactive link-state routing protocol, which uses hello and topology control (TC) messages to discover and then disseminate link state information..." (Accessed via https://en.wikipedia.org/api/rest_v1/page/summary/Optimized_Link_State_Routing_Protocol)
+- License: CC BY-SA 4.0
+
+## Optimized Link State Routing Protocol Version 2 (RFC 7181)
+- Excerpt: "This specification describes version 2 of the Optimized Link State Routing Protocol (OLSRv2) for Mobile Ad Hoc Networks (MANETs)." (Accessed via https://www.rfc-editor.org/rfc/rfc7181.txt)
+- License: Public domain
+
+## Mobile Ad Hoc Network Neighborhood Discovery Protocol (RFC 6130)
+- Excerpt: "This document describes a 1-hop and symmetric 2-hop neighborhood discovery protocol (NHDP) for mobile ad hoc networks (MANETs)." (Accessed via https://www.rfc-editor.org/rfc/rfc6130.txt)
+- License: Public domain
+
+## B.A.T.M.A.N. routing protocol (Wikipedia)
+- Excerpt: "The Better Approach to Mobile Ad-hoc Networking (B.A.T.M.A.N.) is a routing protocol for multi-hop mobile ad hoc networks... intended to replace the Optimized Link State Routing Protocol (OLSR)..." (Accessed via https://en.wikipedia.org/api/rest_v1/page/summary/B.A.T.M.A.N.)
+- License: CC BY-SA 4.0

--- a/docs/manet_plan.md
+++ b/docs/manet_plan.md
@@ -1,0 +1,64 @@
+# Mobile Ad-Hoc Networking (MANET) Notes for bladeRF-wiphy
+
+## bladeRF-wiphy architecture recap
+
+- **Top-level PHY/MAC pipeline.** `wlan_top` integrates the receive and transmit clock domains, FIFO interfaces to the host, automatic gain control handshakes, and the over-the-air IQ sample ports. Its internal TX and RX state machines cover header parsing, payload buffering, ACK handling, and retry timing, providing the core control path for packet exchange.【F:fpga/vhdl/wlan_top.vhd†L34-L143】
+- **Distributed Coordination Function (DCF).** The `wlan_dcf` module implements the CSMA/CA backoff logic using contention window timers, random backoff masking, and SIFS/DIFS gating. It asserts `tx_sifs_ready`/`tx_difs_ready` when the medium is idle and enforces RX blocking while waiting, enabling hardware-assisted contention and ACK turnaround.【F:fpga/vhdl/wlan_dcf.vhd†L26-L140】
+- **PHY framing.** `wlan_framer` computes OFDM signal fields, length/parity bits, and packet CRC bytes before feeding the encoder and modulator, ensuring transmitted frames match IEEE 802.11 formatting constraints.【F:fpga/vhdl/wlan_framer.vhd†L29-L200】
+- **ACK generation.** `wlan_ack_generator` buffers peer MAC addresses, synthesizes acknowledgment payloads, and streams 10-byte ACK responses to the TX datapath once the previous transmission finishes.【F:fpga/vhdl/wlan_ack_generator.vhd†L31-L159】
+
+Together, these VHDL blocks provide a standards-compliant PHY with enough MAC intelligence (DCF + ACK) to interoperate with Linux mac80211 on the host while offloading strict timing requirements to the FPGA fabric.
+
+## Target MANET capability
+
+A MANET allows two or more bladeRF 2.0 micro xA9 radios to form a decentralized network where each node can originate traffic and forward data without infrastructure.【F:docs/external_sources.md†L1-L7】 For the initial milestone—two nodes exchanging traffic—both radios need:
+
+1. A peer-to-peer PHY/MAC link (e.g., 802.11 IBSS or 802.11s mesh) operating on the same channel.
+2. A lightweight routing/control plane so each node discovers its neighbor and exchanges Layer 2/Layer 3 reachability information.
+3. Tooling to configure and monitor the MANET from the host OS.
+
+## Design options and references
+
+### Option A: 802.11 IBSS with host-based MANET routing
+
+1. **Enable IBSS/adhoc mode in mac80211.** bladeRF-wiphy already exposes standard 802.11 frame handling, so enabling the Linux driver to create an IBSS (`iw dev wlan0 ibss join ...`) leverages the existing DCF and ACK support with minimal FPGA changes. Ensure the RX/TX pipeline accepts beacons and peer management frames, and expose configuration bits for channel, BSSID, and beacon intervals via `config_reg` or host control paths.【F:fpga/vhdl/wlan_top.vhd†L44-L78】
+2. **Add beacon support if missing.** IBSS peers periodically transmit beacons. Extend `wlan_framer` or a companion management framer to assemble beacon management frames and schedule them through the TX FSM (new states or timer). Incorporate timestamp updates and capability bits sourced from mac80211.
+3. **Run a routing daemon.** Deploy a proactive protocol such as OLSR/OLSRv2 or BATMAN-adv so nodes automatically exchange topology information. OLSR disseminates link-state updates via hello/TC messages, while OLSRv2 formalizes MANET optimizations; BATMAN focuses on large community meshes.【F:docs/external_sources.md†L9-L26】 Linux packages exist for all three, allowing experimentation without FPGA modifications.
+4. **Two-node validation.** Configure both radios to join the same IBSS SSID/BSSID, start the routing daemon (or rely on static routes for two nodes), and verify bidirectional throughput/latency. Add capture hooks in the RX path (`rx_packet_control`, `rx_fifo_data`) to dump frames for debugging.【F:fpga/vhdl/wlan_top.vhd†L48-L59】
+
+### Option B: 802.11s mesh point implementation
+
+1. **Mesh peering management.** IEEE 802.11s defines mesh peering, path selection, and synchronization. Augment the MAC control plane to handle mesh peering open/confirm frames and path selection frames. These can reuse the existing framer with additional management frame templates and state machine extensions.【F:fpga/vhdl/wlan_framer.vhd†L181-L200】
+2. **Mesh metrics and routing.** For two nodes, the default Hybrid Wireless Mesh Protocol (HWMP) suffices, but integrating with host-based routing (e.g., BATMAN or OLSRv2) provides flexibility. Evaluate whether to keep mesh path selection in userspace (using Linux 802.11s stack) or offload parts to the FPGA.
+3. **Timing considerations.** Mesh requires synchronized beacons (TBTT), so ensure the FPGA exposes accurate TSF updates and supports per-node beacon scheduling. `wlan_top`'s TX FSM could provide hooks for timed transmissions and quick ACK turnaround to meet mesh peer requirements.【F:fpga/vhdl/wlan_top.vhd†L90-L143】
+
+### Routing/control plane choices
+
+| Protocol | Characteristics | Notes |
+| --- | --- | --- |
+| OLSRv2 | Proactive link-state routing standardized for MANETs; relies on NHDP for neighbor discovery.【F:docs/external_sources.md†L9-L18】 | Good for small meshes; existing Linux daemons (olsrd2). |
+| NHDP | 1-hop and 2-hop neighbor discovery used by OLSRv2.【F:docs/external_sources.md†L18-L26】 | Implement in userspace to feed MAC neighbor tables. |
+| BATMAN | Community-driven mesh routing optimizing for large-scale deployments.【F:docs/external_sources.md†L27-L31】 | Linux `batman-adv` module integrates with 802.11s/IBSS. |
+
+## Recommended implementation roadmap
+
+1. **Gap analysis.** Audit existing FPGA/driver support for management frames (beacons, peer link frames) and identify configuration register hooks required for IBSS/mesh parameters.
+2. **Driver enhancements.** Extend the bladeRF-wiphy mac80211 glue layer to expose IBSS/mesh modes, TSF readback, and beacon scheduling. Provide debugfs hooks for MANET metrics.
+3. **FPGA updates.**
+   - Add a management framer path that can craft beacons/mesh frames and enqueue them through `wlan_top`'s TX FSM alongside data traffic.
+   - Provide timers/counters to trigger transmissions and maintain TSF, possibly leveraging `tx_ota_req` handshake for coordination.【F:fpga/vhdl/wlan_top.vhd†L73-L79】
+   - Ensure `wlan_dcf` can honor contention requirements for periodic beacons by exposing contention window tuning parameters.【F:fpga/vhdl/wlan_dcf.vhd†L74-L112】
+4. **Host routing integration.** Package scripts to install and configure OLSRv2 or BATMAN-adv, enabling automatic link bring-up when two nodes detect each other.
+5. **Testing.** Develop a regression plan covering RF loopback, two-node over-the-air IBSS throughput, routing convergence time, and resilience to channel changes. Capture raw IQ and frame logs for analysis using existing FIFO interfaces.【F:fpga/vhdl/wlan_top.vhd†L55-L63】
+
+## External references captured for future study
+
+To keep this repository self-contained, store short excerpts of public-domain/CC-BY sources alongside URLs in `docs/external_sources.md` (added in this change). These cover MANET fundamentals, IEEE 802.11s mesh networking, and candidate routing protocols (OLSR/OLSRv2, NHDP, B.A.T.M.A.N.).
+
+## Host tooling status
+
+The initial host automation described in the roadmap has been implemented in
+[`host/manet`](../host/manet). `setup_ibss.py` performs the IBSS configuration
+and optional OLSR bring-up for a pair of nodes, while `hello_daemon.py` provides
+a minimal NHDP-inspired neighbor discovery loop for verifying that the radios
+are exchanging control traffic once the ad-hoc link is active.

--- a/host/manet/README.md
+++ b/host/manet/README.md
@@ -1,0 +1,41 @@
+# bladeRF-wiphy MANET helpers
+
+The utilities in this directory translate the planning work captured in
+[`docs/manet_plan.md`](../../docs/manet_plan.md) into concrete host-side tooling
+that enables two bladeRF-wiphy nodes to form a basic Mobile Ad-hoc Network
+(MANET).  They focus on the initial milestone of bringing up an IEEE 802.11 IBSS
+link and exchanging neighbor discovery beacons before integrating a
+full-featured routing suite.
+
+## `setup_ibss.py`
+
+`setup_ibss.py` automates the Linux mac80211 steps required to join an ad-hoc
+(IBSS) cell.  It accepts the SSID, operating frequency, and IPv4 addressing
+information, configures deterministic BSSID values (unless one is provided), and
+optionally starts an OLSR/OLSRv2 routing daemon once the wireless link is up.
+
+Typical usage on each bladeRF host is::
+
+    sudo ./setup_ibss.py --interface wlan0 --ssid bladerf-mesh \
+        --frequency 5180 --ip 10.23.0.1/24 --peer 10.23.0.2
+
+The script can also be run in `--dry-run` mode to preview the `iw`/`ip`
+commands it will execute.  When `--olsr` is requested the helper auto-detects an
+available `olsrd2` or `olsrd` binary, generating a throw-away configuration file
+if necessary so that two nodes can immediately exchange routing hellos.
+
+## `hello_daemon.py`
+
+`hello_daemon.py` provides a lightweight UDP-based neighbor discovery loop that
+emits JSON "hello" frames to the IBSS broadcast address and maintains a table of
+recently seen peers.  The state can optionally be persisted to disk for
+integration with external monitoring tools.  This mimics the NeighborHood
+Discovery Protocol (NHDP) stage described in the MANET design notes and offers a
+self-contained validation tool when a full routing daemon is unavailable.
+
+Run it after the IBSS link is up::
+
+    ./hello_daemon.py --ip 10.23.0.1/24 --interface wlan0 --state-file /tmp/neighbors.json
+
+The script prints neighbor summaries whenever it sees an update and writes the
+latest table to the specified state file.

--- a/host/manet/hello_daemon.py
+++ b/host/manet/hello_daemon.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Ad-hoc MANET neighbor discovery helper for bladeRF-wiphy nodes.
+
+This daemon periodically emits a small JSON "hello" message via link-layer
+broadcast and listens for responses from peers joined to the same IBSS cell.
+It provides a lightweight control-plane primitive that mirrors the NHDP style
+neighbor table discussed in the MANET planning notes while avoiding a hard
+dependency on a full routing suite for bring-up tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import json
+import os
+import selectors
+import socket
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+
+DEFAULT_PORT = 6696
+
+
+@dataclass
+class Neighbor:
+    node_id: str
+    address: str
+    last_seen: float
+
+
+class NeighborTable:
+    """Tracks live neighbors and persists summaries to disk."""
+
+    def __init__(self, expiry: float, state_file: Optional[Path]) -> None:
+        self._expiry = expiry
+        self._state_file = state_file
+        self._neighbors: Dict[str, Neighbor] = {}
+        self._dirty = False
+
+    def update(self, neighbor: Neighbor) -> None:
+        previous = self._neighbors.get(neighbor.node_id)
+        if previous is None or previous.address != neighbor.address:
+            self._dirty = True
+        else:
+            # Mark dirty on first sighting after expiry.
+            if time.monotonic() - previous.last_seen > self._expiry:
+                self._dirty = True
+        self._neighbors[neighbor.node_id] = neighbor
+
+    def prune(self) -> None:
+        now = time.monotonic()
+        removed = [node_id for node_id, entry in self._neighbors.items() if now - entry.last_seen > self._expiry]
+        if removed:
+            self._dirty = True
+        for node_id in removed:
+            del self._neighbors[node_id]
+
+    def maybe_persist(self) -> None:
+        if not self._dirty or self._state_file is None:
+            return
+        payload = {
+            "generated_at": time.time(),
+            "neighbors": [
+                {
+                    "node_id": entry.node_id,
+                    "address": entry.address,
+                    "last_seen": entry.last_seen,
+                }
+                for entry in sorted(self._neighbors.values(), key=lambda item: item.node_id)
+            ],
+        }
+        self._state_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        self._dirty = False
+
+    def format_summary(self) -> str:
+        if not self._neighbors:
+            return "No neighbors discovered"
+        lines = ["Discovered neighbors:"]
+        for entry in sorted(self._neighbors.values(), key=lambda item: item.node_id):
+            age = time.monotonic() - entry.last_seen
+            lines.append(f"  - {entry.node_id} @ {entry.address} (age {age:.1f}s)")
+        return "\n".join(lines)
+
+
+@dataclass
+class HelloConfig:
+    source: ipaddress.IPv4Interface
+    node_id: str
+    broadcast: ipaddress.IPv4Address
+    port: int
+    interval: float
+    expiry: float
+    interface: Optional[str]
+    verbose: bool
+
+
+@dataclass
+class HelloMessage:
+    node_id: str
+    address: str
+    timestamp: float
+
+    def encode(self) -> bytes:
+        return json.dumps({"node_id": self.node_id, "address": self.address, "timestamp": self.timestamp}).encode("utf-8")
+
+    @staticmethod
+    def decode(payload: bytes) -> "HelloMessage":
+        decoded = json.loads(payload.decode("utf-8"))
+        return HelloMessage(
+            node_id=str(decoded["node_id"]),
+            address=str(decoded["address"]),
+            timestamp=float(decoded["timestamp"]),
+        )
+
+
+def create_socket(config: HelloConfig) -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    if config.interface:
+        # Linux-specific bind to device to avoid leaking frames onto other NICs.
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, config.interface.encode("utf-8"))
+    sock.bind(("", config.port))
+    return sock
+
+
+def send_hello(sock: socket.socket, config: HelloConfig) -> None:
+    message = HelloMessage(
+        node_id=config.node_id,
+        address=str(config.source.ip),
+        timestamp=time.time(),
+    )
+    sock.sendto(message.encode(), (str(config.broadcast), config.port))
+    if config.verbose:
+        print(f"tx hello -> {config.broadcast} ({len(message.encode())} bytes)")
+
+
+def receive_hello(sock: socket.socket, config: HelloConfig) -> Optional[HelloMessage]:
+    payload, addr = sock.recvfrom(4096)
+    try:
+        message = HelloMessage.decode(payload)
+    except (ValueError, json.JSONDecodeError) as exc:
+        if config.verbose:
+            print(f"Ignoring malformed hello from {addr}: {exc}")
+        return None
+    if message.address == str(config.source.ip) and message.node_id == config.node_id:
+        # Ignore our own broadcast.
+        return None
+    if config.verbose:
+        print(f"rx hello <- {addr[0]}: {message}")
+    return message
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ip", required=True, help="Local IP with prefix length (e.g. 10.23.0.1/24)")
+    parser.add_argument("--node-id", default=os.uname().nodename, help="Identifier advertised to peers")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="UDP port for hello exchanges")
+    parser.add_argument("--interval", type=float, default=1.0, help="Seconds between hello transmissions")
+    parser.add_argument("--expiry", type=float, default=5.0, help="Neighbor expiry interval in seconds")
+    parser.add_argument("--interface", help="Restrict socket binding to a specific interface")
+    parser.add_argument("--state-file", type=Path, help="Optional path to persist neighbor table JSON")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
+    return parser.parse_args(argv)
+
+
+def build_config(args: argparse.Namespace) -> HelloConfig:
+    try:
+        source = ipaddress.ip_interface(args.ip)
+    except ValueError as exc:
+        print(f"error: invalid IP address '{args.ip}': {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    if not isinstance(source, ipaddress.IPv4Interface):
+        print("error: only IPv4 is currently supported", file=sys.stderr)
+        sys.exit(2)
+
+    broadcast = source.network.broadcast_address
+    if broadcast == source.ip:
+        print("error: broadcast address overlaps with host address", file=sys.stderr)
+        sys.exit(2)
+
+    return HelloConfig(
+        source=source,
+        node_id=str(args.node_id),
+        broadcast=broadcast,
+        port=int(args.port),
+        interval=float(args.interval),
+        expiry=float(args.expiry),
+        interface=args.interface,
+        verbose=bool(args.verbose),
+    )
+
+
+def run_daemon(config: HelloConfig, state_file: Optional[Path]) -> None:
+    selector = selectors.DefaultSelector()
+    table = NeighborTable(config.expiry, state_file)
+    sock = create_socket(config)
+    sock.setblocking(False)
+    selector.register(sock, selectors.EVENT_READ)
+
+    next_tx = time.monotonic()
+
+    try:
+        while True:
+            timeout = max(0.0, next_tx - time.monotonic())
+            events = selector.select(timeout)
+            for key, _ in events:
+                if key.fileobj is sock:
+                    message = receive_hello(sock, config)
+                    if message is None:
+                        continue
+                    table.update(
+                        Neighbor(
+                            node_id=message.node_id,
+                            address=message.address,
+                            last_seen=time.monotonic(),
+                        )
+                    )
+                    print(table.format_summary())
+            now = time.monotonic()
+            if now >= next_tx:
+                send_hello(sock, config)
+                next_tx = now + config.interval
+            table.prune()
+            table.maybe_persist()
+    except KeyboardInterrupt:
+        print("Stopping hello daemon")
+    finally:
+        selector.unregister(sock)
+        sock.close()
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    config = build_config(args)
+    run_daemon(config, args.state_file)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/host/manet/setup_ibss.py
+++ b/host/manet/setup_ibss.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Utility helpers to configure a bladeRF-wiphy interface for MANET use.
+
+The script provisions an interface for IEEE 802.11 IBSS (ad-hoc) operation,
+assigns an IP address, and optionally launches an OLSR routing daemon if one
+is present on the system.  It codifies the high-level plan captured in
+``docs/manet_plan.md`` by providing a repeatable automation entrypoint that can
+be invoked on both bladeRF 2.0 micro xA9 nodes.
+
+Example usage for a two-node testbed::
+
+    sudo ./setup_ibss.py --interface wlan0 --ssid bladerf-mesh \
+        --frequency 5180 --ip 10.23.0.1/24 --peer 10.23.0.2
+
+    sudo ./setup_ibss.py --interface wlan0 --ssid bladerf-mesh \
+        --frequency 5180 --ip 10.23.0.2/24 --peer 10.23.0.1
+
+After the interface is configured, a minimal UDP hello daemon (see
+``hello_daemon.py``) can be launched to verify bi-directional reachability and
+export neighbor state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class CommandResult:
+    """Container for executed command metadata."""
+
+    command: List[str]
+    returncode: int
+
+
+class CommandRunner:
+    """Thin wrapper around subprocess that logs and optionally dry-runs."""
+
+    def __init__(self, dry_run: bool = False) -> None:
+        self.dry_run = dry_run
+
+    def run(self, argv: Iterable[str], *, check: bool = True) -> CommandResult:
+        command = list(argv)
+        print(f"$ {' '.join(shlex.quote(arg) for arg in command)}")
+        if self.dry_run:
+            return CommandResult(command, 0)
+        completed = subprocess.run(command, check=check)
+        return CommandResult(command, completed.returncode)
+
+
+def ensure_tool(binary: str) -> str:
+    """Return the absolute path to *binary* or exit with an error."""
+
+    resolved = shutil.which(binary)
+    if resolved is None:
+        print(f"error: required tool '{binary}' not found in PATH", file=sys.stderr)
+        sys.exit(2)
+    return resolved
+
+
+def compute_ibss_bssid(ssid: str, frequency_mhz: int) -> str:
+    """Derive a locally-administered BSSID that remains stable per SSID.
+
+    The procedure is deterministic and keeps the multicast bit clear while
+    asserting the locally administered bit.  This mirrors how Linux mac80211
+    synthesizes IBSS identifiers when a BSSID is not provided manually.
+    """
+
+    import hashlib
+
+    digest = hashlib.sha256(f"{ssid}\0{frequency_mhz}".encode("utf-8")).digest()
+    raw = bytearray(digest[:6])
+    raw[0] |= 0x02  # locally administered
+    raw[0] &= 0xFE  # unicast
+    return ":".join(f"{b:02x}" for b in raw)
+
+
+def configure_interface(
+    runner: CommandRunner,
+    *,
+    interface: str,
+    ssid: str,
+    frequency_mhz: int,
+    address: ipaddress.IPv4Interface,
+    beacon_interval: int,
+    mtu: Optional[int],
+    bssid: Optional[str],
+    tx_power_dbm: Optional[float],
+) -> None:
+    """Bring the interface into IBSS mode and assign the provided address."""
+
+    ensure_tool("iw")
+    ensure_tool("ip")
+
+    bssid_value = bssid or compute_ibss_bssid(ssid, frequency_mhz)
+
+    # Bring the link down while reconfiguring to avoid mac80211 rejects.
+    runner.run(["ip", "link", "set", interface, "down"])
+    runner.run(["iw", "dev", interface, "set", "type", "ibss"])
+
+    join_command = [
+        "iw",
+        "dev",
+        interface,
+        "ibss",
+        "join",
+        ssid,
+        str(frequency_mhz),
+        "HT20",
+        bssid_value,
+        "beacon-interval",
+        str(beacon_interval),
+    ]
+    runner.run(join_command)
+
+    runner.run(["ip", "addr", "flush", "dev", interface])
+    runner.run(["ip", "addr", "add", str(address), "dev", interface])
+    if mtu is not None:
+        runner.run(["ip", "link", "set", interface, "mtu", str(mtu)])
+    runner.run(["ip", "link", "set", interface, "up"])
+
+    if tx_power_dbm is not None:
+        # iw expects mBm (dBm * 100)
+        tx_power_mbm = int(tx_power_dbm * 100)
+        runner.run([
+            "iw",
+            "dev",
+            interface,
+            "set",
+            "txpower",
+            "fixed",
+            str(tx_power_mbm),
+        ])
+
+    print(
+        textwrap.dedent(
+            f"""
+            Interface {interface} joined IBSS '{ssid}' ({bssid_value}) on {frequency_mhz} MHz.
+            Assigned address {address} with beacon interval {beacon_interval} TU.
+            """
+        ).strip()
+    )
+
+
+def add_peer_route(runner: CommandRunner, *, interface: str, peer: ipaddress.IPv4Address) -> None:
+    """Install a host route towards *peer* via the MANET interface."""
+
+    runner.run(["ip", "route", "replace", str(peer), "dev", interface])
+
+
+def build_olsr_command(
+    *,
+    interface: str,
+    local_ip: ipaddress.IPv4Address,
+    preferred: Optional[str],
+    provided_config: Optional[Path],
+) -> Optional[List[str]]:
+    """Return a launch command for OLSR/OLSRv2 if available."""
+
+    binary_candidates = [preferred] if preferred else []
+    binary_candidates += ["olsrd2", "olsrd"]
+
+    binary_path: Optional[str] = None
+    for candidate in binary_candidates:
+        if candidate is None:
+            continue
+        resolved = shutil.which(candidate)
+        if resolved:
+            binary_path = resolved
+            break
+
+    if binary_path is None:
+        return None
+
+    binary_name = os.path.basename(binary_path)
+
+    if provided_config is not None:
+        return [binary_path, "-f", str(provided_config)]
+
+    if binary_name.startswith("olsrd2"):
+        # Generate a minimal OLSRv2 config that only enables the interface.
+        cfg = textwrap.dedent(
+            f"""
+            [global]
+            fork false
+
+            [log]
+            information true
+
+            [interface]
+            ifname "{interface}"
+            """
+        ).strip()
+    else:
+        # Legacy olsrd configuration
+        cfg = textwrap.dedent(
+            f"""
+            DebugLevel 1
+            IpVersion 4
+            Hna4 {{}}
+            UseHysteresis no
+            LinkQualityLevel 2
+            LinkQualityAlgorithm "etx_ff"
+            AllowNoInt yes
+            Pollrate 0.05
+            TcRedundancy 2
+            MprCoverage 7
+            Willingness 3
+
+            InterfaceDefaults {{
+                HelloInterval 2.0
+                HelloValidityTime 20.0
+                TcInterval 5.0
+                TcValidityTime 60.0
+            }}
+
+            Interface "{interface}" {{
+                Mode "mesh"
+                Ip4Broadcast 255.255.255.255
+            }}
+            """
+        ).strip()
+
+    temp_fd, temp_path = tempfile.mkstemp(prefix="manet-olsr-", suffix=".conf")
+    with os.fdopen(temp_fd, "w", encoding="utf-8") as handle:
+        handle.write(cfg)
+
+    if binary_name.startswith("olsrd"):
+        return [binary_path, "-i", interface, "-nofork", "-f", temp_path]
+
+    # olsrd2
+    return [binary_path, "-f", temp_path]
+
+
+def launch_olsr(
+    runner: CommandRunner,
+    *,
+    interface: str,
+    ip_address: ipaddress.IPv4Interface,
+    preferred_binary: Optional[str],
+    config: Optional[Path],
+) -> None:
+    command = build_olsr_command(
+        interface=interface,
+        local_ip=ip_address.ip,
+        preferred=preferred_binary,
+        provided_config=config,
+    )
+    if command is None:
+        print("warning: no OLSR binary found; skipping MANET routing daemon")
+        return
+
+    runner.run(command, check=False)
+    print(
+        textwrap.dedent(
+            """
+            OLSR daemon launched in the foreground. Use Ctrl-C to terminate when finished.
+            For unattended operation consider supervising the command with systemd or tmux.
+            """
+        ).strip()
+    )
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--interface", required=True, help="wireless interface name")
+    parser.add_argument("--ssid", required=True, help="IBSS network identifier")
+    parser.add_argument(
+        "--frequency",
+        type=int,
+        required=True,
+        help="Operating frequency in MHz (e.g. 5180)",
+    )
+    parser.add_argument(
+        "--ip",
+        required=True,
+        help="IPv4 address with prefix length, e.g. 10.23.0.1/24",
+    )
+    parser.add_argument(
+        "--beacon-interval",
+        type=int,
+        default=100,
+        help="Beacon interval in TU (default: 100)",
+    )
+    parser.add_argument(
+        "--bssid",
+        help="Optional fixed BSSID; defaults to deterministic hash of SSID/frequency",
+    )
+    parser.add_argument(
+        "--peer",
+        action="append",
+        help="Optional peer IPv4 address to install as a host route (repeatable)",
+    )
+    parser.add_argument(
+        "--mtu",
+        type=int,
+        help="Override MTU on the MANET interface",
+    )
+    parser.add_argument(
+        "--tx-power",
+        type=float,
+        help="Transmit power in dBm (requires regulatory permissions)",
+    )
+    parser.add_argument(
+        "--olsr",
+        action="store_true",
+        help="Attempt to launch an OLSR/OLSRv2 daemon after joining the IBSS",
+    )
+    parser.add_argument(
+        "--olsr-binary",
+        help="Preferred OLSR binary name/path (overrides auto-detection)",
+    )
+    parser.add_argument(
+        "--olsr-config",
+        type=Path,
+        help="Explicit OLSR configuration file to pass to the daemon",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        address = ipaddress.ip_interface(args.ip)
+    except ValueError as exc:  # pragma: no cover - argparse guards typical usage
+        print(f"error: invalid IP specification: {exc}", file=sys.stderr)
+        return 2
+
+    peers = []
+    if args.peer:
+        for peer in args.peer:
+            try:
+                peers.append(ipaddress.ip_address(peer))
+            except ValueError as exc:
+                print(f"error: invalid peer address {peer!r}: {exc}", file=sys.stderr)
+                return 2
+
+    runner = CommandRunner(dry_run=args.dry_run)
+
+    configure_interface(
+        runner,
+        interface=args.interface,
+        ssid=args.ssid,
+        frequency_mhz=args.frequency,
+        address=address,
+        beacon_interval=args.beacon_interval,
+        mtu=args.mtu,
+        bssid=args.bssid,
+        tx_power_dbm=args.tx_power,
+    )
+
+    for peer in peers:
+        add_peer_route(runner, interface=args.interface, peer=peer)
+
+    if args.olsr:
+        launch_olsr(
+            runner,
+            interface=args.interface,
+            ip_address=address,
+            preferred_binary=args.olsr_binary,
+            config=args.olsr_config,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add host-side MANET helpers to configure IBSS links and run a lightweight neighbor discovery daemon
- document the new scripts in host/manet/README.md and reference them from the existing MANET planning notes and top-level README

## Testing
- python3 -m compileall host/manet

------
https://chatgpt.com/codex/tasks/task_b_68d9d11c59e8832e85c01bc70d2153f8